### PR TITLE
Feature/start config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Generate a Pandora-like offline music station from a single song. The files are saved on your computer so you can play them as much as you want.
 
-You supply a single song and *playlistfromsong* goes to the respective song page on last.fm and extracts the song suggestions. You can also provide a bearer token (`--bearer`) to use Spotify instead of last.fm. Then song audio is downloaded from the respective Youtube video for each song suggestion. 
+You supply a single song and *playlistfromsong* goes to the respective song page on last.fm and extracts the song suggestions.
+You can also provide a bearer token (`--bearer` or use program config) to use Spotify instead of last.fm.
+Then song audio is downloaded from the respective Youtube video for each song suggestion. 
 
 # Dependencies 
 
@@ -45,3 +47,19 @@ playlistfromsong --song 'Miles Davis Blue In Green'
 You can also use Spotify if you provide a Bearer token (which [you can get here](https://developer.spotify.com/web-api/console/get-track/)):
 
 ![](http://i.imgur.com/uzEEEFh.gif)
+
+You can also set the spotify bearer token
+
+```
+playlistfromsong config --open
+```
+
+That command will open the config file with default application.
+
+Edit the config file and add following entry 
+
+    spotify_bearer_token: <your spotify bearer token>
+
+change `<your spotify bearer token>` with actual token and save.
+
+After editing the config file, everytime you use the program that token will be loaded.

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setup(
         "requests",
         "youtube_dl",
         'lxml',
+        'appdirs',
+        'pyyaml',
     ],
     setup_requires=['pytest-runner'],
     tests_require=[


### PR DESCRIPTION
i add program config, so user don't have to input spotify bearer token everytime.

they can open it manually or use `playlist config --open` to open the config program.